### PR TITLE
Enable Stale bot on adoptium-support repo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'jbs:needs-report'
+        days-before-stale: 90
+        days-before-close: 30
+        remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,10 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been waiting on the original poster to reply for many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
+        stale-issue-message: >
+          We are marking this issue as stale because it has not been updated for a while. This is just a way to keep the support issues queue manageable.
+          
+          It will be closed soon unless the stale label is removed by a committer, or a new comment is made.
         stale-issue-label: 'stale'
         exempt-issue-labels: 'jbs:needs-report'
         days-before-stale: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
+        stale-issue-message: 'This issue is stale because it has been waiting on the original poster to reply for many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
         stale-issue-label: 'stale'
         exempt-issue-labels: 'jbs:needs-report'
         days-before-stale: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
 name: "Close stale issues"
 on:
+  workflow_dispatch:
   schedule:
   - cron: "0 0 * * *"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'


### PR DESCRIPTION
closes: https://github.com/adoptium/adoptium/issues/141

I'd like to propose that we enable [actions/stale](https://github.com/actions/stale) on the adoptium-support repo. It will allow us to close out issues that have not had a response from users.