### PR TITLE
Replace reference to upstream builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -74,9 +74,9 @@ body:
       description: |
         Please specify exactly what Java versions you tested with, for example by pasting the output of `java --version`.
 
-        If available, test with an upstream build:
+        If available, test with a supported build:
 
-          * https://adoptopenjdk.net/upstream.html (8, 11)
+          * https://adoptium.net/marketplace
           * http://jdk.java.net/ (anything newer than 8, 11)
       render: shell
   - type: textarea


### PR DESCRIPTION
Upstream builds at AdoptOpenJDK are discontinued. Temurin *is* now the upstream build.
Suggest that users test with an alternate JDK publisher from the marketplace.