### PR TITLE
Avoid continually removing the stale label using a keep label.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,8 +24,9 @@ jobs:
           
           It will be closed soon unless the stale label is removed by a committer, or a new comment is made.
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'jbs:needs-report'
+        exempt-issue-labels: 'jbs:needs-report,keep'
         days-before-stale: 90
         days-before-close: 30
         operations-per-run: 100
         remove-stale-when-updated: true
+        labels-to-add-when-unstale: 'keep'


### PR DESCRIPTION
This could be useful to avoid continually removing the `stale` label by using a `keep` label.

Example can be found on #292 

If you merge this pull request you can then add the keep label and forget about contanstly removing the stale one :)